### PR TITLE
[Feat] 면접 관련 엔티티 구현 및 엔티티 구조 통합

### DIFF
--- a/src/main/java/com/dgu/review/ReviewApplication.java
+++ b/src/main/java/com/dgu/review/ReviewApplication.java
@@ -2,8 +2,10 @@ package com.dgu.review;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ReviewApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/dgu/review/domain/common/entity/BaseEntity.java
+++ b/src/main/java/com/dgu/review/domain/common/entity/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.dgu.review.domain.common.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/dgu/review/domain/community/entity/CommunityPage.java
+++ b/src/main/java/com/dgu/review/domain/community/entity/CommunityPage.java
@@ -1,5 +1,6 @@
 package com.dgu.review.domain.community.entity;
 
+import com.dgu.review.domain.common.entity.BaseEntity;
 import com.dgu.review.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -17,7 +18,7 @@ import java.time.LocalDateTime;
 @Builder
 @Entity
 @Table(name = "community_page")
-public class CommunityPage{
+public class CommunityPage extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "page_id")
     private Long id;
@@ -48,11 +49,4 @@ public class CommunityPage{
     foreignKey = @ForeignKey(name = "fk_cp_author")) //외래키 제약 이름 지정
     private User author; //객체 연관관계를 테이블의 외래키로 바꿔서 저장/조회
 
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/dgu/review/domain/interview/entity/AiFeedback.java
+++ b/src/main/java/com/dgu/review/domain/interview/entity/AiFeedback.java
@@ -1,0 +1,32 @@
+package com.dgu.review.domain.interview.entity;
+
+import com.dgu.review.domain.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ai_feedback")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiFeedback extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "text")
+    private String aiFeedback;
+
+    @Column(columnDefinition = "text")
+    private String peerCriteriaFeedback;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recording_id", nullable = false)
+    private Recording recording;
+
+}

--- a/src/main/java/com/dgu/review/domain/interview/entity/InterviewQuestion.java
+++ b/src/main/java/com/dgu/review/domain/interview/entity/InterviewQuestion.java
@@ -1,0 +1,44 @@
+package com.dgu.review.domain.interview.entity;
+
+import com.dgu.review.domain.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "interview_question")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InterviewQuestion extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = "TINYINT")
+    private Integer questionNumber;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String question;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interview_session_id", nullable = false)
+    private InterviewSession interviewSession;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_question_id")
+    private InterviewQuestion parentQuestion;
+
+    @OneToMany(mappedBy = "parentQuestion", cascade = CascadeType.ALL, orphanRemoval = false)
+    private List<InterviewQuestion> childrenQuestions = new ArrayList<>();
+
+    @OneToOne(mappedBy = "interviewQuestion", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private Recording recording;
+}

--- a/src/main/java/com/dgu/review/domain/interview/entity/InterviewSession.java
+++ b/src/main/java/com/dgu/review/domain/interview/entity/InterviewSession.java
@@ -1,6 +1,7 @@
 package com.dgu.review.domain.interview.entity;
 
 import com.dgu.review.domain.common.entity.BaseEntity;
+import com.dgu.review.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,4 +36,8 @@ public class InterviewSession extends BaseEntity {
 
     @OneToMany(mappedBy = "interviewSession", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<InterviewQuestion> questions = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 }

--- a/src/main/java/com/dgu/review/domain/interview/entity/InterviewSession.java
+++ b/src/main/java/com/dgu/review/domain/interview/entity/InterviewSession.java
@@ -1,0 +1,38 @@
+package com.dgu.review.domain.interview.entity;
+
+import com.dgu.review.domain.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "interview_session")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InterviewSession extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 100)
+    private String title;
+
+    @Column(length = 1024, nullable = false)
+    private String resumeObjectKey;
+
+    @Column(length = 100)
+    private String jobRole;
+
+    //private User user;
+
+    @OneToMany(mappedBy = "interviewSession", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<InterviewQuestion> questions = new ArrayList<>();
+}

--- a/src/main/java/com/dgu/review/domain/interview/entity/Recording.java
+++ b/src/main/java/com/dgu/review/domain/interview/entity/Recording.java
@@ -1,11 +1,15 @@
 package com.dgu.review.domain.interview.entity;
 
 import com.dgu.review.domain.common.entity.BaseEntity;
+import com.dgu.review.domain.peerFeedback.entity.PeerFeedback;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "recording")
@@ -31,4 +35,7 @@ public class Recording extends BaseEntity {
 
     @OneToOne(mappedBy = "recording", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private AiFeedback aiFeedback;
+
+    @OneToMany(mappedBy = "recording", fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<PeerFeedback> peerFeedbacks = new ArrayList<>();
 }

--- a/src/main/java/com/dgu/review/domain/interview/entity/Recording.java
+++ b/src/main/java/com/dgu/review/domain/interview/entity/Recording.java
@@ -1,0 +1,34 @@
+package com.dgu.review.domain.interview.entity;
+
+import com.dgu.review.domain.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "recording")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Recording extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 1024)
+    private String objectKey;
+
+    @Column(columnDefinition = "text", nullable = false)
+    private String sttText;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interview_question_id", nullable = false)
+    private InterviewQuestion interviewQuestion;
+
+    @OneToOne(mappedBy = "recording", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private AiFeedback aiFeedback;
+}

--- a/src/main/java/com/dgu/review/domain/peerfeedback/entity/PeerFeedback.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/entity/PeerFeedback.java
@@ -14,7 +14,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-
+@Entity
 @Table(name = "peer_feedback")
 public class PeerFeedback extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,4 +33,8 @@ public class PeerFeedback extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false,
     foreignKey = @ForeignKey(name = "fk_pf_user"))
     private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recording_id", nullable = false)
+    private Recording recording;
 }

--- a/src/main/java/com/dgu/review/domain/peerfeedback/entity/PeerFeedback.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/entity/PeerFeedback.java
@@ -1,5 +1,7 @@
-package com.dgu.review.domain.peerfeedback.entity;
+package com.dgu.review.domain.peerFeedback.entity;
 
+import com.dgu.review.domain.common.entity.BaseEntity;
+import com.dgu.review.domain.interview.entity.Recording;
 import com.dgu.review.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -14,7 +16,7 @@ import lombok.*;
 @Builder
 
 @Table(name = "peer_feedback")
-public class PeerFeedback{
+public class PeerFeedback extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -24,7 +26,7 @@ public class PeerFeedback{
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "recoding_id", nullable = false,
     foreignKey = @ForeignKey(name = "fk_pf_recoding"))
-    private Recoding recoding;
+    private Recording recoding;
 
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/dgu/review/domain/test/TestController.java
+++ b/src/main/java/com/dgu/review/domain/test/TestController.java
@@ -2,7 +2,6 @@ package com.dgu.review.domain.test;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController

--- a/src/main/java/com/dgu/review/domain/user/entity/User.java
+++ b/src/main/java/com/dgu/review/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.dgu.review.domain.user.entity;
 
+import com.dgu.review.domain.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -19,7 +20,7 @@ uniqueConstraints = {
         @UniqueConstraint(name = "uk_users_email", columnNames = "email"),
         @UniqueConstraint(name = "uk_users_name", columnNames = "name")
 })
-public class User{
+public class User extends BaseEntity {
     @Id //PK생성
     @GeneratedValue(strategy = GenerationType.IDENTITY) //AUTO_INCREMENT
     private Long id;
@@ -27,7 +28,4 @@ public class User{
     @Column(nullable = false, length = 255)
     private String email;
 
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/dgu/review/domain/user/entity/User.java
+++ b/src/main/java/com/dgu/review/domain/user/entity/User.java
@@ -1,10 +1,15 @@
 package com.dgu.review.domain.user.entity;
 
 import com.dgu.review.domain.common.entity.BaseEntity;
+import com.dgu.review.domain.community.entity.CommunityPage;
+import com.dgu.review.domain.interview.entity.InterviewSession;
+import com.dgu.review.domain.peerFeedback.entity.PeerFeedback;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 /*
   User 테이블 매핑
  */
@@ -28,4 +33,12 @@ public class User extends BaseEntity {
     @Column(nullable = false, length = 255)
     private String email;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<InterviewSession> interviewSessions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CommunityPage> communityPages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PeerFeedback> peerFeedbacks = new ArrayList<>();
 }


### PR DESCRIPTION
## 📝 요약
- 면접 관련 엔티티를 구현하고 다른 도메인과 엔티티 구조를 통합한다.

## 🔍 변경 사항
1. `InterviewSession`, `InterviewQuestion`, `Recording`, `AiFeedback` 엔티티 구현
2. `createdAt`, `updatedAt` 필드 `BaseEntity` 상속으로 수정
- 기존 민지님이 구현하신 `User`, `CommunityPage`, `PeerFeedback` 엔티티의 `createdAt`, `updatedAt` 필드를 제거하고 해당 엔티티가 `BaseEntity`를 상속받도록 수정했습니다.
3. 양방향 연관관계 매핑
- 면접 관련 엔티티와 민지님이 구현하신 엔티티의 연관관계 매핑했습니다.


## 📋 체크리스트
- [x] 면접 관련 엔티티 구현
- [x]  BaseEntity 상속으로 수정
- [x] 양방향 연관관계 매핑


## ✨ 참고 사항
제가 개발하면서 기존 erd에서 필드명이나 타입을 조금씩 수정한 게 있습니다! erd에도 반영해놓았으니 확인해주세요.

## 🔗 관련 이슈
Close #3 