### PR TITLE
[Feat] 핸들러 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dgu/review/domain/peerfeedback/entity/PeerFeedback.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/entity/PeerFeedback.java
@@ -26,7 +26,7 @@ public class PeerFeedback extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "recoding_id", nullable = false,
     foreignKey = @ForeignKey(name = "fk_pf_recoding"))
-    private Recording recoding;
+    private Recording recording;
 
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/dgu/review/domain/test/TestController.java
+++ b/src/main/java/com/dgu/review/domain/test/TestController.java
@@ -11,5 +11,6 @@ public class TestController {
     @GetMapping("/test")
     public String test() {
         return "test";
+        
     }
 }

--- a/src/main/java/com/dgu/review/global/exception/ApiException.java
+++ b/src/main/java/com/dgu/review/global/exception/ApiException.java
@@ -1,17 +1,21 @@
 package com.dgu.review.global.exception;
 
-//서비스 에러 
+// 서비스 에러
 public class ApiException extends RuntimeException {
- private final String errorCode;
- private final int httpStatus;
 
- public ApiException(String errorCode, int httpStatus) {
-     super(errorCode);
-     this.errorCode = errorCode;
-     this.httpStatus = httpStatus;
- }
+    private final ErrorCode errorCode;
 
+    // ErrorCode의 기본 메시지 사용
+    public ApiException(ErrorCode errorCode) {
+        super(errorCode.defaultMessage());
+        this.errorCode = errorCode;
+    }
 
- public String getErrorCode() { return errorCode; }
- public int getHttpStatus() { return httpStatus; }
+    // 커스텀 메시지로 덮어쓰기
+    public ApiException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() { return errorCode; }
 }

--- a/src/main/java/com/dgu/review/global/exception/ApiException.java
+++ b/src/main/java/com/dgu/review/global/exception/ApiException.java
@@ -1,0 +1,17 @@
+package com.dgu.review.global.exception;
+
+//서비스 에러 
+public class ApiException extends RuntimeException {
+ private final String errorCode;
+ private final int httpStatus;
+
+ public ApiException(String errorCode, int httpStatus) {
+     super(errorCode);
+     this.errorCode = errorCode;
+     this.httpStatus = httpStatus;
+ }
+
+
+ public String getErrorCode() { return errorCode; }
+ public int getHttpStatus() { return httpStatus; }
+}

--- a/src/main/java/com/dgu/review/global/exception/ErrorCode.java
+++ b/src/main/java/com/dgu/review/global/exception/ErrorCode.java
@@ -1,0 +1,32 @@
+package com.dgu.review.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+public enum ErrorCode {
+
+	BAD_REQUEST("BAD_REQUEST",HttpStatus.BAD_REQUEST, "잘못된 요청입니다. ");
+
+	private final String code;
+	private final HttpStatus status;
+	private final String defaultMessage;
+
+	ErrorCode(String code, HttpStatus status, String defaultMessage) {
+		this.code = code;
+		this.status = status;
+		this.defaultMessage = defaultMessage;
+	}
+
+	public String code() {
+		return code;
+	}
+
+	public HttpStatus status() {
+		return status;
+	}
+
+	public String defaultMessage() {
+		return defaultMessage;
+	}
+}

--- a/src/main/java/com/dgu/review/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dgu/review/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.dgu.review.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.dgu.review.global.response.ApiResponse;
+
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+ @ExceptionHandler(ApiException.class)
+ public ResponseEntity<ApiResponse<Void>> handleApiException(ApiException ex) {
+     ApiResponse<Void> body = ApiResponse.error(ex.getErrorCode());
+     
+     
+     return ResponseEntity.status(ex.getHttpStatus()).body(body);
+ }
+ 
+
+ // 바인딩 실패 
+ @ExceptionHandler({ MethodArgumentNotValidException.class, BindException.class, ConstraintViolationException.class })
+ public ResponseEntity<ApiResponse<Void>> handleValidation(Exception ex) {
+     ApiResponse<Void> body = ApiResponse.error("VALIDATION_ERROR");
+     return ResponseEntity.status(422).body(body);
+ }
+ 
+ // 그 외 예상 못한 예외 → 500
+ @ExceptionHandler(Exception.class)
+ public ResponseEntity<ApiResponse<Void>> handleUnexpected(Exception ex) {
+     // 로그는 여기서 남기고, 응답은 규격 유지
+	 log.error("Unexpected error", ex);
+     ApiResponse<Void> body = ApiResponse.error("INTERNAL_ERROR");
+     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+ }
+}
+

--- a/src/main/java/com/dgu/review/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dgu/review/global/exception/GlobalExceptionHandler.java
@@ -16,29 +16,27 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
- @ExceptionHandler(ApiException.class)
- public ResponseEntity<ApiResponse<Void>> handleApiException(ApiException ex) {
-     ApiResponse<Void> body = ApiResponse.error(ex.getErrorCode());
-     
-     
-     return ResponseEntity.status(ex.getHttpStatus()).body(body);
- }
- 
+	@ExceptionHandler(ApiException.class)
+	public ResponseEntity<ApiResponse<Void>> handleApiException(ApiException ex) {
+		var ec = ex.getErrorCode();
+	    ApiResponse<Void> body = ApiResponse.error(ec.code(), ex.getMessage()); 
+	    return ResponseEntity.status(ec.status()).body(body);
+	}
 
- // 바인딩 실패 
- @ExceptionHandler({ MethodArgumentNotValidException.class, BindException.class, ConstraintViolationException.class })
- public ResponseEntity<ApiResponse<Void>> handleValidation(Exception ex) {
-     ApiResponse<Void> body = ApiResponse.error("VALIDATION_ERROR");
-     return ResponseEntity.status(422).body(body);
- }
- 
- // 그 외 예상 못한 예외 → 500
- @ExceptionHandler(Exception.class)
- public ResponseEntity<ApiResponse<Void>> handleUnexpected(Exception ex) {
-     // 로그는 여기서 남기고, 응답은 규격 유지
-	 log.error("Unexpected error", ex);
-     ApiResponse<Void> body = ApiResponse.error("INTERNAL_ERROR");
-     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
- }
+	// 바인딩 실패
+	@ExceptionHandler({ MethodArgumentNotValidException.class, BindException.class,
+			ConstraintViolationException.class })
+	public ResponseEntity<ApiResponse<Void>> handleValidation(Exception ex) {
+		ApiResponse<Void> body = ApiResponse.error("VALIDATION_ERROR","요청 값이 유효하지 않습니다.");
+		return ResponseEntity.status(422).body(body);
+	}
+
+	// 그 외 예상 못한 예외 → 500
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiResponse<Void>> handleUnexpected(Exception ex) {
+		// 로그는 여기서 남기고, 응답은 규격 유지
+		log.error("Unexpected error", ex);
+		ApiResponse<Void> body = ApiResponse.error("INTERNAL_ERROR","처리 중 오류가 발생했습니다.");
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+	}
 }
-

--- a/src/main/java/com/dgu/review/global/response/ApiResponse.java
+++ b/src/main/java/com/dgu/review/global/response/ApiResponse.java
@@ -1,0 +1,40 @@
+package com.dgu.review.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Slf4j
+public class ApiResponse<T> {
+
+    private String errorCode;
+    private String message = "OK";
+    private T result;
+
+    // 성공 응답
+    public static <T> ApiResponse<T> ok(T result) {
+        return ApiResponse.<T>builder()
+                .errorCode(null)
+                .message("OK")
+                .result(result)
+                .build();
+    }
+
+    // 실패 응답 
+    public static <T> ApiResponse<T> error(String errorCode) {
+        return ApiResponse.<T>builder()
+                .errorCode(errorCode)
+                .message("error")
+                .result(null)
+                .build();
+    }
+}

--- a/src/main/java/com/dgu/review/global/response/ApiResponse.java
+++ b/src/main/java/com/dgu/review/global/response/ApiResponse.java
@@ -29,12 +29,12 @@ public class ApiResponse<T> {
                 .build();
     }
 
-    // 실패 응답 
-    public static <T> ApiResponse<T> error(String errorCode) {
+    // 실패 (코드/메시지 지정)
+    public static <T> ApiResponse<T> error(String errorCode, String message) {
         return ApiResponse.<T>builder()
                 .errorCode(errorCode)
-                .message("error")
-                .result(null)
+                .message(message)
                 .build();
     }
+
 }


### PR DESCRIPTION
## 📝 요약
- 전역 예외 처리(GlobalExceptionHandler)와 응답 포맷(ApiResponse) 통일 로직을 구현했습니다.
- 성공/실패 시 일관된 JSON 포맷을 제공하도록 개선했습니다.

## 🔍 변경 사항
1. 응답 통일 객체 ApiResponse 구현
- 성공 시: { "errorCode": null, "message": "OK", "result": {...} }
- 실패 시: { "errorCode": "CODE", "message": "잘못된 요청입니다."}

2. 전역 예외 처리기 GlobalExceptionHandler 추가
- 비즈니스 예외(ApiException) → 상태코드 및 에러코드 그대로 반환
- 검증/바인딩 실패(MethodArgumentNotValidException, BindException, ConstraintViolationException) → 422 VALIDATION_ERROR
- 그 외 예상치 못한 예외 → 500 INTERNAL_ERROR

3. ErrorCode 추가 
  - 공통 에러코드 관리 (예: `BAD_REQUEST`, `NOT_FOUND` 등)
  - 각 코드에 HTTP 상태와 기본 메시지 포함


## 📋 체크리스트
- [x] ApiResponse 통일 포맷 구현
- [x] GlobalExceptionHandler 작성 (비즈니스/검증/기타 예외 처리)
- [x] 성공/실패 응답이 일관된 JSON으로 내려오는 것 확인 (테스트 코드 통해서 )


## ✨ 참고 사항
노션 공유문서/핸들러랑 같이 확인 부탁드립니다

## 🔗 관련 이슈
Close #7 