### PR TITLE
[Refactor] PR #16의 머지 이후 코드리뷰 반영

### DIFF
--- a/src/main/java/com/dgu/review/domain/interview/entity/Recording.java
+++ b/src/main/java/com/dgu/review/domain/interview/entity/Recording.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,6 +31,9 @@ public class Recording extends BaseEntity {
     @Column(columnDefinition = "text", nullable = false)
     private String sttText;
 
+    @Column(name = "failed_at")
+    private LocalDateTime failedAt;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "interview_question_id", nullable = false)
     private InterviewQuestion interviewQuestion;
@@ -50,4 +54,9 @@ public class Recording extends BaseEntity {
     public void attachSttText(String sttText) {
         this.sttText = sttText;
     }
+
+    public void updateFailedAt(LocalDateTime failedAt) {
+        this.failedAt = failedAt;
+    }
+
 }

--- a/src/main/java/com/dgu/review/domain/interview/service/RecordingQueryService.java
+++ b/src/main/java/com/dgu/review/domain/interview/service/RecordingQueryService.java
@@ -31,7 +31,7 @@ public class RecordingQueryService {
         InterviewQuestion root = getRoot(current);
         var status = statusService.getStatus(recordingId);
 
-        if (status == RecordingStatus.FAILED || status == null) {
+        if (status == RecordingStatus.FAILED || recording.getFailedAt() != null) {
             return RecordingResultsResponse.builder()
                     .sessionId(current.getInterviewSession().getId())
                     .status(ProgressStatus.FAILED)
@@ -39,21 +39,24 @@ public class RecordingQueryService {
                     .build();
         }
 
-        if (status != RecordingStatus.FOLLOWUP_GENERATED) {
+        boolean isSuccess = (status == RecordingStatus.FOLLOWUP_GENERATED) ||
+                (status == null && recording.getFailedAt() == null);
+
+        if (isSuccess) {
+            var next = decideNextPayload(current, root);
             return RecordingResultsResponse.builder()
                     .sessionId(current.getInterviewSession().getId())
-                    .status(ProgressStatus.WORKING)
-                    .next(null)
+                    .status(ProgressStatus.READY)
+                    .next(next)
                     .build();
         }
 
-        var next = decideNextPayload(current, root);
-
         return RecordingResultsResponse.builder()
                 .sessionId(current.getInterviewSession().getId())
-                .status(ProgressStatus.READY)
-                .next(next)
+                .status(ProgressStatus.WORKING)
+                .next(null)
                 .build();
+
     }
 
     private NextPayload decideNextPayload(InterviewQuestion current, InterviewQuestion currentRoot) {

--- a/src/main/java/com/dgu/review/domain/interview/service/RecordingQueryService.java
+++ b/src/main/java/com/dgu/review/domain/interview/service/RecordingQueryService.java
@@ -106,7 +106,16 @@ public class RecordingQueryService {
 
     private InterviewQuestion getRoot(InterviewQuestion q) {
         var cur = q;
-        while (cur.getParentQuestion() != null) cur = cur.getParentQuestion();
+        int depth = 0;
+
+        while (cur.getParentQuestion() != null) {
+            cur = cur.getParentQuestion();
+
+            if (++depth > 10) {
+                log.error("질문 데이터 순환 참조 의심. recordingId: {}", q.getRecording().getId());
+                throw new ApiException(ErrorCode.DATA_INTEGRITY_VIOLATED);
+            }
+        }
         return cur;
     }
 

--- a/src/main/java/com/dgu/review/domain/interview/service/RecordingTranscriber.java
+++ b/src/main/java/com/dgu/review/domain/interview/service/RecordingTranscriber.java
@@ -17,6 +17,7 @@ import java.io.InputStreamReader;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 
@@ -44,10 +45,10 @@ public class RecordingTranscriber {
     @Transactional
     @Async
     public void sttAsyncWorker(Long recordingId) {
-        try {
+        Recording recording = recordingRepo.findById(recordingId)
+                .orElseThrow(() -> new ApiException(ErrorCode.RECORDING_NOT_FOUND));
 
-            Recording recording = recordingRepo.findById(recordingId)
-                    .orElseThrow(() -> new ApiException(ErrorCode.RECORDING_NOT_FOUND));
+        try {
 
             long started = System.currentTimeMillis();
             log.info("[sttWorker:start] recordingId={}, thread={}, audioKey={}",
@@ -103,9 +104,11 @@ public class RecordingTranscriber {
 
             } else {
                 statusService.setStatus(recordingId, RecordingStatus.FAILED, Duration.ofMinutes(30));
+                recording.updateFailedAt(LocalDateTime.now());
             }
         } catch (Exception e) {
             statusService.setStatus(recordingId, RecordingStatus.FAILED, null);
+            recording.updateFailedAt(LocalDateTime.now());
             log.error("STT 워커 실행 실패 recordingId={}", recordingId, e); // 내부 로그
             throw new RuntimeException("STT 워커 실행 실패", e);
         }

--- a/src/main/java/com/dgu/review/global/exception/ErrorCode.java
+++ b/src/main/java/com/dgu/review/global/exception/ErrorCode.java
@@ -57,6 +57,10 @@ public enum ErrorCode {
 
 	REDIS_KEY_NOT_FOUND("REDIS_KEY_NOT_FOUND",
 			HttpStatus.BAD_REQUEST, "해당 key가 존재하지 않습니다."),
+
+	DATA_INTEGRITY_VIOLATED("DATA_INTEGRITY_VIOLATED",
+			HttpStatus.BAD_REQUEST, "데이터 순환 참조"),
+
 	;
 	private final String code;
 	private final HttpStatus status;


### PR DESCRIPTION
## 📝 요약
- PR #16에서 머지 이후 추가된 코드리뷰를 반영하여 코드를 리팩터링했습니다.

## 🔍 변경 사항
1. Polling API 실패 상태 응답 분기처리
   - RecordingResults를 폴링하는 API에서 Redis 키 만료 후 polling이 들어왔을 때, 실패 이후 키 만료인지 성공 이후 키 만료인지 분기처리가 되지 않던 문제가 있었습니다.
   - 상태 FAILED 시 엔티티에 failedAt을 저장하고, 상태 조회 시 failedAt 유무를 먼저 확인하여 실패 상태를 명확히 판별하도록 했습니다.
   - failedAt이 없고 Redis 키가 만료된 경우는 성공으로 간주하여 올바른 READY 응답을 반환합니다.
   - failedAt이 있고 Redis 키가 만료된 경우는 실패로 간주하여 FAILED 응답을 반환합니다.
2. RecordingResults 폴링에 사용하던 getRoot 메서드 무한 루프 방지 로직 추가
 - 10회 이상으로 부모 질문을 찾아가는 흐름이 발생할 시 무한 반복으로 간주하여 예외를 발생합니다.


## 📋 체크리스트
- [x] 키 만료시 성공/실패 응답 분기처리
- [x] 무한 루프 방지 로직 추가

## ✨ 참고 사항
#16 PR의 리뷰에도 댓글을 남겨놨으니 함께 보시면 좋을 것 같습니다!
추후 고도화 시 별도 워커 분리 예정입니다.

## 🔗 관련 이슈
