### PR TITLE
[Feat] 타인평가 기능 구현 

### DIFF
--- a/src/main/java/com/dgu/review/domain/interview/repository/RecordingRepository.java
+++ b/src/main/java/com/dgu/review/domain/interview/repository/RecordingRepository.java
@@ -1,16 +1,18 @@
 package com.dgu.review.domain.interview.repository;
 
 
+import com.dgu.review.domain.interview.entity.InterviewQuestion;
 import com.dgu.review.domain.interview.entity.Recording;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Pageable;
 import java.util.List;
+import java.util.Optional;
 
 
 public interface RecordingRepository extends JpaRepository<Recording, Long> {
-
+    Optional<Recording> findByInterviewQuestion(InterviewQuestion interviewQuestion);
     // 전체 루트 녹음 갯수
     @Query("""
         SELECT COUNT(r)

--- a/src/main/java/com/dgu/review/domain/interview/repository/RecordingRepository.java
+++ b/src/main/java/com/dgu/review/domain/interview/repository/RecordingRepository.java
@@ -1,33 +1,35 @@
 package com.dgu.review.domain.interview.repository;
 
-import com.dgu.review.domain.interview.entity.InterviewQuestion;
+
 import com.dgu.review.domain.interview.entity.Recording;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.domain.Pageable;
 import java.util.List;
-import java.util.Optional;
+
 
 public interface RecordingRepository extends JpaRepository<Recording, Long> {
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("update Recording r set r.sttText = :text where r.id = :id")
-    int updateSttTextById(@Param("id") Long id, @Param("text") String text);
-
-    List<Recording> findAllByInterviewQuestion_InterviewSession_Id(Long sessionId);
-
-    Optional<Recording> findByInterviewQuestion(InterviewQuestion interviewQuestion);
-
+    // 전체 루트 녹음 갯수
     @Query("""
-    SELECT r FROM Recording r
-    JOIN FETCH r.interviewQuestion iq
-    JOIN FETCH iq.interviewSession s
-    WHERE iq.parentQuestion IS NULL
-      AND s.user.id <> :currentUserId
-    ORDER BY FUNCTION('RAND')
-    LIMIT 1
-""")
-    Optional<Recording> findRandomRootRecording(@Param("currentUserId") Long currentUserId);
+        SELECT COUNT(r)
+        FROM Recording r
+        JOIN r.interviewQuestion iq
+        JOIN iq.interviewSession s
+        WHERE iq.parentQuestion IS NULL
+          AND s.user.id <> :currentUserId
+    """)
+    long countRootRecordingsExcludingUser(@Param("currentUserId") Long currentUserId);
 
+    // 특정 offset에서 1개만 조회
+    @Query("""
+        SELECT r
+        FROM Recording r
+        JOIN FETCH r.interviewQuestion iq
+        JOIN FETCH iq.interviewSession s
+        WHERE iq.parentQuestion IS NULL
+          AND s.user.id <> :currentUserId
+    """)
+    List<Recording> findRootRecordingAtOffset(@Param("currentUserId") Long currentUserId, Pageable pageable);
 }

--- a/src/main/java/com/dgu/review/domain/interview/repository/RecordingRepository.java
+++ b/src/main/java/com/dgu/review/domain/interview/repository/RecordingRepository.java
@@ -21,6 +21,8 @@ public interface RecordingRepository extends JpaRepository<Recording, Long> {
         JOIN iq.interviewSession s
         WHERE iq.parentQuestion IS NULL
           AND s.user.id <> :currentUserId
+          AND r.sttText IS NOT NULL
+          AND r.sttText <> ''
     """)
     long countRootRecordingsExcludingUser(@Param("currentUserId") Long currentUserId);
 
@@ -32,6 +34,9 @@ public interface RecordingRepository extends JpaRepository<Recording, Long> {
         JOIN FETCH iq.interviewSession s
         WHERE iq.parentQuestion IS NULL
           AND s.user.id <> :currentUserId
+          AND r.sttText IS NOT NULL
+          AND r.sttText <> ''
+        ORDER BY r.id
     """)
     List<Recording> findRootRecordingAtOffset(@Param("currentUserId") Long currentUserId, Pageable pageable);
 }

--- a/src/main/java/com/dgu/review/domain/interview/repository/RecordingRepository.java
+++ b/src/main/java/com/dgu/review/domain/interview/repository/RecordingRepository.java
@@ -18,4 +18,16 @@ public interface RecordingRepository extends JpaRepository<Recording, Long> {
     List<Recording> findAllByInterviewQuestion_InterviewSession_Id(Long sessionId);
 
     Optional<Recording> findByInterviewQuestion(InterviewQuestion interviewQuestion);
+
+    @Query("""
+    SELECT r FROM Recording r
+    JOIN FETCH r.interviewQuestion iq
+    JOIN FETCH iq.interviewSession s
+    WHERE iq.parentQuestion IS NULL
+      AND s.user.id <> :currentUserId
+    ORDER BY FUNCTION('RAND')
+    LIMIT 1
+""")
+    Optional<Recording> findRandomRootRecording(@Param("currentUserId") Long currentUserId);
+
 }

--- a/src/main/java/com/dgu/review/domain/peerfeedback/controller/PeerFeedbackController.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/controller/PeerFeedbackController.java
@@ -5,7 +5,11 @@ import com.dgu.review.domain.peerfeedback.dto.PeerFeedbackResponse;
 import com.dgu.review.domain.peerfeedback.dto.RandomRecordingResponse;
 import com.dgu.review.domain.peerfeedback.service.PeerFeedbackService;
 import com.dgu.review.domain.user.entity.User;
+import com.dgu.review.domain.user.repository.UserRepository;
+import com.dgu.review.global.exception.ApiException;
+import com.dgu.review.global.exception.ErrorCode;
 import com.dgu.review.global.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -17,7 +21,7 @@ import org.springframework.web.bind.annotation.*;
 public class PeerFeedbackController {
 
     private final PeerFeedbackService peerFeedbackService;
-
+    private final UserRepository userRepository;
     /**
      * 랜덤 평가 대상 조회
      */
@@ -35,19 +39,18 @@ public class PeerFeedbackController {
      * 타인평가 제출
      */
     @PostMapping("/recordings/{recordingId}/feedbacks")
-    public ResponseEntity<ApiResponse<PeerFeedbackResponse>> submitFeedback(
+    public ResponseEntity<Void> createFeedback(
             @PathVariable Long recordingId,
-            @Validated @RequestBody PeerFeedbackRequest request
+            @Valid @RequestBody PeerFeedbackRequest request
     ) {
-        // 임시
-        User evaluator = User.builder()
-                .id(1L) // 로그인 완성되면 SecurityContext에서 대체
-                .email("testuser@example.com")
-                .build();
+        // 로그인 미구현 상태이므로 evaluator 하드코딩
+        User evaluator = userRepository.findById(1L)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
 
-        var res = peerFeedbackService.createFeedback(recordingId, request, evaluator);
-        return ResponseEntity.ok(ApiResponse.ok(res));
+        peerFeedbackService.createFeedback(recordingId, request, evaluator);
+        return ResponseEntity.noContent().build();
     }
+
 
     /**
      * 내가 작성한 평가 상세 조회

--- a/src/main/java/com/dgu/review/domain/peerfeedback/controller/PeerFeedbackController.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/controller/PeerFeedbackController.java
@@ -1,0 +1,62 @@
+package com.dgu.review.domain.peerfeedback.controller;
+
+import com.dgu.review.domain.peerfeedback.dto.PeerFeedbackRequest;
+import com.dgu.review.domain.peerfeedback.dto.PeerFeedbackResponse;
+import com.dgu.review.domain.peerfeedback.dto.RandomRecordingResponse;
+import com.dgu.review.domain.peerfeedback.service.PeerFeedbackService;
+import com.dgu.review.domain.user.entity.User;
+import com.dgu.review.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/peer-reviews")
+public class PeerFeedbackController {
+
+    private final PeerFeedbackService peerFeedbackService;
+
+    /**
+     * 랜덤 평가 대상 조회
+     */
+    @GetMapping("/random")
+    public ResponseEntity<ApiResponse<RandomRecordingResponse>> getRandomRecording() {
+
+        // 임시
+        Long currentUserId = 1L; // 추후 교체
+
+        var res = peerFeedbackService.getRandomRecording(currentUserId);
+        return ResponseEntity.ok(ApiResponse.ok(res));
+    }
+
+    /**
+     * 타인평가 제출
+     */
+    @PostMapping("/recordings/{recordingId}/feedbacks")
+    public ResponseEntity<ApiResponse<PeerFeedbackResponse>> submitFeedback(
+            @PathVariable Long recordingId,
+            @Validated @RequestBody PeerFeedbackRequest request
+    ) {
+        // 임시
+        User evaluator = User.builder()
+                .id(1L) // 로그인 완성되면 SecurityContext에서 대체
+                .email("testuser@example.com")
+                .build();
+
+        var res = peerFeedbackService.createFeedback(recordingId, request, evaluator);
+        return ResponseEntity.ok(ApiResponse.ok(res));
+    }
+
+    /**
+     * 내가 작성한 평가 상세 조회
+     */
+    @GetMapping("/mypage/feedbacks/{feedbackId}")
+    public ResponseEntity<ApiResponse<PeerFeedbackResponse>> getMyFeedbackDetail(
+            @PathVariable Long feedbackId
+    ) {
+        var res = peerFeedbackService.getFeedbackDetail(feedbackId);
+        return ResponseEntity.ok(ApiResponse.ok(res));
+    }
+}

--- a/src/main/java/com/dgu/review/domain/peerfeedback/dto/PeerFeedbackRequest.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/dto/PeerFeedbackRequest.java
@@ -1,0 +1,18 @@
+package com.dgu.review.domain.peerfeedback.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PeerFeedbackRequest {
+
+    @NotBlank(message = "평가 내용은 필수입니다.")
+    @Size(min = 100, message = "평가 내용은 100byte 이상이어야 합니다.")
+    private String body;
+
+    @Size(max = 30, message = "추가질문은 최대 30자까지 입력 가능합니다.")
+    private String followUpQuestion;
+}

--- a/src/main/java/com/dgu/review/domain/peerfeedback/dto/PeerFeedbackResponse.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/dto/PeerFeedbackResponse.java
@@ -14,6 +14,5 @@ public class PeerFeedbackResponse {
     private String body;              // 평가 본문
     private String followUpQuestion;  // 추가 질문
     private String jobRole;           // 피평가자 직무명
-    private String recordingUrl;      // 녹음 파일 URL
     private LocalDateTime createdAt;  // 작성 시각
 }

--- a/src/main/java/com/dgu/review/domain/peerfeedback/dto/PeerFeedbackResponse.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/dto/PeerFeedbackResponse.java
@@ -9,11 +9,11 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PeerFeedbackResponse {
-    private Long feedbackId;
-    private Long recordingId;
-    private Long evaluatorId;
-    private Long intervieweeId;
-    private String body;
-    private String followUpQuestion;
-    private LocalDateTime createdAt;
+    private Long feedbackId;          // 피드백 ID
+    private String question;          // 질문 내용
+    private String body;              // 평가 본문
+    private String followUpQuestion;  // 추가 질문
+    private String jobRole;           // 피평가자 직무명
+    private String recordingUrl;      // 녹음 파일 URL
+    private LocalDateTime createdAt;  // 작성 시각
 }

--- a/src/main/java/com/dgu/review/domain/peerfeedback/dto/PeerFeedbackResponse.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/dto/PeerFeedbackResponse.java
@@ -1,0 +1,19 @@
+package com.dgu.review.domain.peerfeedback.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PeerFeedbackResponse {
+    private Long feedbackId;
+    private Long recordingId;
+    private Long evaluatorId;
+    private Long intervieweeId;
+    private String body;
+    private String followUpQuestion;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/dgu/review/domain/peerfeedback/dto/RandomRecordingResponse.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/dto/RandomRecordingResponse.java
@@ -1,0 +1,17 @@
+package com.dgu.review.domain.peerfeedback.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RandomRecordingResponse {
+
+    private Long recordingId;       // 녹음 ID
+    private String question;        // 질문 내용
+    private String sttText;         // 답변 텍스트(STT)
+    private String jobRole;         // 직군
+
+}

--- a/src/main/java/com/dgu/review/domain/peerfeedback/dto/RandomRecordingResponse.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/dto/RandomRecordingResponse.java
@@ -13,5 +13,5 @@ public class RandomRecordingResponse {
     private String question;        // 질문 내용
     private String sttText;         // 답변 텍스트(STT)
     private String jobRole;         // 직군
-
+    private String recordingUrl;    // S3 Presigned GET URL
 }

--- a/src/main/java/com/dgu/review/domain/peerfeedback/entity/PeerFeedback.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/entity/PeerFeedback.java
@@ -34,5 +34,10 @@ public class PeerFeedback extends BaseEntity {
     foreignKey = @ForeignKey(name = "fk_pf_user"))
     private User user;
 
+    @Column(length = 100)
+    private String followUpQuestion;
+
+    @Column(nullable = false)
+    private int length; // 평가 내용 길이
 
 }

--- a/src/main/java/com/dgu/review/domain/peerfeedback/entity/PeerFeedback.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/entity/PeerFeedback.java
@@ -37,7 +37,4 @@ public class PeerFeedback extends BaseEntity {
     @Column(length = 100)
     private String followUpQuestion;
 
-    @Column(nullable = false)
-    private int length; // 평가 내용 길이
-
 }

--- a/src/main/java/com/dgu/review/domain/peerfeedback/service/PeerFeedbackService.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/service/PeerFeedbackService.java
@@ -14,9 +14,12 @@ import com.dgu.review.global.exception.ApiException;
 import com.dgu.review.global.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import com.dgu.review.domain.interview.service.InterviewObjectReadService;
 
-import java.util.Optional;
+import java.util.Random;
+
 
 @Service
 @RequiredArgsConstructor
@@ -25,36 +28,52 @@ public class PeerFeedbackService {
 
     private final PeerFeedbackRepository peerFeedbackRepository;
     private final RecordingRepository recordingRepository;
+    private final InterviewObjectReadService interviewObjectReadService;
 
     /**
      * 랜덤 녹음 조회
      */
     public RandomRecordingResponse getRandomRecording(Long currentUserId) {
-        Recording randomRecording = recordingRepository.findRandomRootRecording(currentUserId)
-                .orElseThrow(() -> new ApiException(ErrorCode.RECORDING_NOT_FOUND, "평가할 녹음을 찾을 수 없습니다."));
+
+        long totalCount = recordingRepository.countRootRecordingsExcludingUser(currentUserId);
+        if (totalCount == 0) {
+            throw new ApiException(ErrorCode.RECORDING_NOT_FOUND);
+        }
+
+        int randomIndex = new Random().nextInt((int) totalCount);
+        var pageable = PageRequest.of(randomIndex, 1);
+
+        Recording randomRecording = recordingRepository
+                .findRootRecordingAtOffset(currentUserId, pageable)
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new ApiException(ErrorCode.RECORDING_NOT_FOUND));
 
         InterviewQuestion question = randomRecording.getInterviewQuestion();
         InterviewSession session = question.getInterviewSession();
-        User interviewee = session.getUser();
+
+        String recordingUrl = interviewObjectReadService.createRecordingGetUrl(randomRecording.getObjectKey());
 
         return new RandomRecordingResponse(
                 randomRecording.getId(),
                 question.getQuestion(),
                 randomRecording.getSttText(),
-                session.getJobRole()
+                session.getJobRole(),
+                recordingUrl
         );
     }
 
     /**
      * 타인평가 저장
      */
-    public PeerFeedbackResponse createFeedback(Long recordingId, PeerFeedbackRequest request, User evaluator) {
+    @Transactional
+    public void createFeedback(Long recordingId, PeerFeedbackRequest request, User evaluator) {
         Recording recording = recordingRepository.findById(recordingId)
-                .orElseThrow(() -> new ApiException(ErrorCode.RECORDING_NOT_FOUND, "녹음 정보를 찾을 수 없습니다.")); // ✅ 수정
+                .orElseThrow(() -> new ApiException(ErrorCode.RECORDING_NOT_FOUND));
 
-        // 자기 자신 평가 방지
-        if (recording.getInterviewQuestion().getInterviewSession().getUser().getId().equals(evaluator.getId())) {
-            throw new ApiException(ErrorCode.BAD_REQUEST, "자기 자신의 답변은 평가할 수 없습니다."); // ✅ 수정
+        if (recording.getInterviewQuestion().getInterviewSession().getUser().getId()
+                .equals(evaluator.getId())) {
+            throw new ApiException(ErrorCode.SELF_FEEDBACK_NOT_ALLOWED);
         }
 
         PeerFeedback feedback = PeerFeedback.builder()
@@ -65,36 +84,36 @@ public class PeerFeedbackService {
                 .build();
 
         peerFeedbackRepository.save(feedback);
-
-        return new PeerFeedbackResponse(
-                feedback.getId(),
-                recording.getId(),
-                evaluator.getId(),
-                recording.getInterviewQuestion().getInterviewSession().getUser().getId(),
-                feedback.getBody(),
-                feedback.getFollowUpQuestion(),
-                feedback.getCreatedAt()
-        );
     }
 
     /**
      * 내가 작성한 평가 상세 조회
      */
     public PeerFeedbackResponse getFeedbackDetail(Long feedbackId) {
+
+        Long currentUserId = 1L;
         PeerFeedback feedback = peerFeedbackRepository.findById(feedbackId)
-                .orElseThrow(() -> new ApiException(ErrorCode.PEER_FEEDBACK_NOT_FOUND, "피드백 정보를 찾을 수 없습니다.")); // ✅ 새 항목 필요
+                .orElseThrow(() -> new ApiException(ErrorCode.PEER_FEEDBACK_NOT_FOUND));
+
+
+        if (!feedback.getUser().getId().equals(currentUserId)) {
+            throw new ApiException(ErrorCode.FORBIDDEN_RESOURCE);
+        }
 
         Recording recording = feedback.getRecording();
         InterviewQuestion question = recording.getInterviewQuestion();
-        Long intervieweeId = question.getInterviewSession().getUser().getId();
+        InterviewSession session = question.getInterviewSession();
+
+        String recordingUrl = interviewObjectReadService.createRecordingGetUrl(recording.getObjectKey());
+
 
         return new PeerFeedbackResponse(
                 feedback.getId(),
-                recording.getId(),
-                feedback.getUser().getId(),
-                intervieweeId,
+                question.getQuestion(),
                 feedback.getBody(),
                 feedback.getFollowUpQuestion(),
+                session.getJobRole(),
+                recordingUrl,
                 feedback.getCreatedAt()
         );
     }

--- a/src/main/java/com/dgu/review/domain/peerfeedback/service/PeerFeedbackService.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/service/PeerFeedbackService.java
@@ -1,0 +1,101 @@
+package com.dgu.review.domain.peerfeedback.service;
+
+import com.dgu.review.domain.interview.entity.InterviewQuestion;
+import com.dgu.review.domain.interview.entity.InterviewSession;
+import com.dgu.review.domain.interview.entity.Recording;
+import com.dgu.review.domain.peerfeedback.dto.PeerFeedbackRequest;
+import com.dgu.review.domain.peerfeedback.dto.PeerFeedbackResponse;
+import com.dgu.review.domain.peerfeedback.dto.RandomRecordingResponse;
+import com.dgu.review.domain.peerfeedback.entity.PeerFeedback;
+import com.dgu.review.domain.peerfeedback.repository.PeerFeedbackRepository;
+import com.dgu.review.domain.interview.repository.RecordingRepository;
+import com.dgu.review.domain.user.entity.User;
+import com.dgu.review.global.exception.ApiException;
+import com.dgu.review.global.exception.ErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PeerFeedbackService {
+
+    private final PeerFeedbackRepository peerFeedbackRepository;
+    private final RecordingRepository recordingRepository;
+
+    /**
+     * 랜덤 녹음 조회
+     */
+    public RandomRecordingResponse getRandomRecording(Long currentUserId) {
+        Recording randomRecording = recordingRepository.findRandomRootRecording(currentUserId)
+                .orElseThrow(() -> new ApiException(ErrorCode.RECORDING_NOT_FOUND, "평가할 녹음을 찾을 수 없습니다."));
+
+        InterviewQuestion question = randomRecording.getInterviewQuestion();
+        InterviewSession session = question.getInterviewSession();
+        User interviewee = session.getUser();
+
+        return new RandomRecordingResponse(
+                randomRecording.getId(),
+                question.getQuestion(),
+                randomRecording.getSttText(),
+                session.getJobRole()
+        );
+    }
+
+    /**
+     * 타인평가 저장
+     */
+    public PeerFeedbackResponse createFeedback(Long recordingId, PeerFeedbackRequest request, User evaluator) {
+        Recording recording = recordingRepository.findById(recordingId)
+                .orElseThrow(() -> new ApiException(ErrorCode.RECORDING_NOT_FOUND, "녹음 정보를 찾을 수 없습니다.")); // ✅ 수정
+
+        // 자기 자신 평가 방지
+        if (recording.getInterviewQuestion().getInterviewSession().getUser().getId().equals(evaluator.getId())) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, "자기 자신의 답변은 평가할 수 없습니다."); // ✅ 수정
+        }
+
+        PeerFeedback feedback = PeerFeedback.builder()
+                .recording(recording)
+                .user(evaluator)
+                .body(request.getBody())
+                .followUpQuestion(request.getFollowUpQuestion())
+                .build();
+
+        peerFeedbackRepository.save(feedback);
+
+        return new PeerFeedbackResponse(
+                feedback.getId(),
+                recording.getId(),
+                evaluator.getId(),
+                recording.getInterviewQuestion().getInterviewSession().getUser().getId(),
+                feedback.getBody(),
+                feedback.getFollowUpQuestion(),
+                feedback.getCreatedAt()
+        );
+    }
+
+    /**
+     * 내가 작성한 평가 상세 조회
+     */
+    public PeerFeedbackResponse getFeedbackDetail(Long feedbackId) {
+        PeerFeedback feedback = peerFeedbackRepository.findById(feedbackId)
+                .orElseThrow(() -> new ApiException(ErrorCode.PEER_FEEDBACK_NOT_FOUND, "피드백 정보를 찾을 수 없습니다.")); // ✅ 새 항목 필요
+
+        Recording recording = feedback.getRecording();
+        InterviewQuestion question = recording.getInterviewQuestion();
+        Long intervieweeId = question.getInterviewSession().getUser().getId();
+
+        return new PeerFeedbackResponse(
+                feedback.getId(),
+                recording.getId(),
+                feedback.getUser().getId(),
+                intervieweeId,
+                feedback.getBody(),
+                feedback.getFollowUpQuestion(),
+                feedback.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/dgu/review/domain/peerfeedback/service/PeerFeedbackService.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/service/PeerFeedbackService.java
@@ -113,7 +113,6 @@ public class PeerFeedbackService {
                 feedback.getBody(),
                 feedback.getFollowUpQuestion(),
                 session.getJobRole(),
-                recordingUrl,
                 feedback.getCreatedAt()
         );
     }

--- a/src/main/java/com/dgu/review/global/exception/ErrorCode.java
+++ b/src/main/java/com/dgu/review/global/exception/ErrorCode.java
@@ -82,6 +82,9 @@ public enum ErrorCode {
 	DATA_INTEGRITY_VIOLATED("DATA_INTEGRITY_VIOLATED",
 			HttpStatus.BAD_REQUEST, "데이터 순환 참조"),
 
+    PEER_FEEDBACK_NOT_FOUND("PEER_FEEDBACK_NOT_FOUND",
+            HttpStatus.NOT_FOUND, "해당 피드백 정보를 찾을 수 없습니다."),
+
 	;
 
 	private final String code;

--- a/src/main/java/com/dgu/review/global/exception/ErrorCode.java
+++ b/src/main/java/com/dgu/review/global/exception/ErrorCode.java
@@ -85,6 +85,10 @@ public enum ErrorCode {
     PEER_FEEDBACK_NOT_FOUND("PEER_FEEDBACK_NOT_FOUND",
             HttpStatus.NOT_FOUND, "해당 피드백 정보를 찾을 수 없습니다."),
 
+    SELF_FEEDBACK_NOT_ALLOWED("SELF_FEEDBACK_NOT_ALLOWED",
+            HttpStatus.BAD_REQUEST, "자기 자신의 답변은 평가할 수 없습니다."),
+
+
 	;
 
 	private final String code;


### PR DESCRIPTION
## 📝 요약
- 타인평가 전체 기능을 신규 구현했습니다. 
- 사용자는 다른 사용자의 루트질문 녹음을 랜덤으로 평가할 수 있으며, 평가 후 평가 내용을 저장하고 자신이 작성한 평가를 조회할 수 있습니다.

## 🔍 변경 사항
1. PeerFeedbackController 구현
   - GET /api/peer-reviews/random
     현재 하드코딩된 사용자(userId=1)를 기준으로 자기 자신 제외 + 루트 질문의 녹음을 랜덤 조회.
   - POST /api/peer-reviews/recordings/{recordingId}/feedbacks
       -  요청 본문(PeerFeedbackRequest) 검증 후 타인평가 저장.
       -  자기 자신 평가 방지 로직 포함.
   -  GET /api/peer-reviews/mypage/feedbacks/{feedbackId}
       - 내가 작성한 평가 상세 반환.
2. PeerFeedbackService 구현
   - 타인평가 기능의 핵심 비즈니스 로직 담당 서비스로 랜덤 평가 대상(타인의 루트질문 녹음) 조회, 피드백 저장, 내가 작성한 평가 상세조회 로직을 처리함
    - 자기 자신 평가를 방지하고, Validation(100byte 이상, 30자 이하)을 통과해야 저장되도록 구현함

3. DTO( PeerFeedbackRequest, PeerFeedbackResponse, RandomRecordingResponse) 구현
   -  PeerFeedbackRequest: 평가 작성 요청 시 입력 데이터 
   -  PeerFeedbackResponse: 저장된 평가 정보 반환용 DTO (평가자, 평가받는 사람, 본문, 추가질문, 생성일 포함)
   -  RandomRecordingResponse: 랜덤 조회 시 반환되는 평가 대상 정보 (질문, 답변 텍스트, 직군 등 포함) 

4. RecordingRepository 보완
   - 랜덤 조회 JPQL 추가로 자기 자신 것을 제외하고 루트 질문들중 랜덤으로 보여질 수 있게 구현.
   - 직군 표시는 Recording -> InterviewQuestion -> InterviewSession.jobRole 경로 사용.
5. ErrorCode 추
   - PEER_FEEDBACK_NOT_FOUND 추가
   
## 📋 체크리스트
- [ ] 타인평가 랜덤 조회 API 구현 (/api/mypage/feedbacks/{feedbackId})
- [ ] 타인평가 등록 API 구현 (/api/peer-reviews/recordings/{recordingId}/feedbacks)
- [ ] 내가 작성한 평가 상세 조회 API 구현  (/api/peer-reviews/recordings/{recordingId})
- [ ] 글자수 제한, 자기 평가 방지 동작 확인
- [ ] 스웨거를 통한 전체 플로우 테스트 완료


## ✨ 참고 사항
현재 로그인 기능이 미구현 상태이므로 하드코딩으로 남겨두었습니다.

## 🔗 관련 이슈
Close #28 
