### PR TITLE
[Refactor] 랜덤 질문에 대한 record url 발급 분리&키 변경

### DIFF
--- a/src/main/java/com/dgu/review/domain/interview/controller/InterviewPresignController.java
+++ b/src/main/java/com/dgu/review/domain/interview/controller/InterviewPresignController.java
@@ -37,6 +37,15 @@ public class InterviewPresignController {
      RecordingUploadUrlResponse res = interviewUploadService.createRecordingPutUrl(req, userId);
      return ResponseEntity.ok(res);
  }
+ @PostMapping("/recording/feedback-question")
+ public ResponseEntity<RecordingUploadUrlResponse> presignRecordforRandomQuestionPutUrl(
+         @Valid @RequestBody RecordingUploadUrlRequest req
+ ) {
+     Long userId = getUserService.getUserId(); 
+
+     RecordingUploadUrlResponse res = interviewUploadService.createfeedbackQuestionRecordingPutUrl(req, userId);
+     return ResponseEntity.ok(res);
+ }
  
  @PostMapping("/resume")
  public ResponseEntity<ResumeUploadUrlResponse> presignResumePutUrl(@RequestParam(name = "fileName", required = true) String fileName) {

--- a/src/main/java/com/dgu/review/domain/interview/entity/FeedbackQuestion.java
+++ b/src/main/java/com/dgu/review/domain/interview/entity/FeedbackQuestion.java
@@ -1,0 +1,59 @@
+package com.dgu.review.domain.interview.entity;
+
+import com.dgu.review.domain.peerfeedback.entity.PeerFeedback;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "feedback_question")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedbackQuestion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String question;
+
+    @Column(columnDefinition = "text", name = "ai_feedback")
+    private String aiFeedback;
+
+    @Column(columnDefinition = "text", name = "self_feedback")
+    private String selfFeedback;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interview_session_id", nullable = false)
+    private InterviewSession interviewSession;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_question_id")
+    private InterviewQuestion parentQuestion;
+
+    @OneToOne(mappedBy = "feedbackQuestion", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private Recording recording;
+
+    @OneToOne(mappedBy = "generatedQuestion", fetch = FetchType.LAZY)
+    private PeerFeedback sourcePeerFeedback;
+
+    public void attachRecording(Recording recording) {
+        this.recording = recording;
+        if (recording != null) {
+            recording.attachToFeedbackQuestion(this);
+        }
+    }
+
+    public void attachAiFeedback(String aiFeedback) {
+        this.aiFeedback = aiFeedback;
+    }
+
+    public void attachSelfFeedback(String selfFeedback) {
+        this.selfFeedback = selfFeedback;
+    }
+}

--- a/src/main/java/com/dgu/review/domain/interview/entity/Recording.java
+++ b/src/main/java/com/dgu/review/domain/interview/entity/Recording.java
@@ -35,16 +35,30 @@ public class Recording extends BaseEntity {
     private LocalDateTime failedAt;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "interview_question_id", nullable = false)
+    @JoinColumn(name = "interview_question_id")
     private InterviewQuestion interviewQuestion;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feedback_question_id")
+    private FeedbackQuestion feedbackQuestion;
 
     @OneToMany(mappedBy = "recording", fetch = FetchType.LAZY, orphanRemoval = true)
     private List<PeerFeedback> peerFeedbacks = new ArrayList<>();
 
     public void attachToQuestion(InterviewQuestion question) {
         this.interviewQuestion = question;
+        this.feedbackQuestion = null;
+
         if (question != null && question.getRecording() != this) {
             question.attachRecording(this);
+        }
+    }
+
+    public void attachToFeedbackQuestion(FeedbackQuestion feedbackQuestion) {
+        this.feedbackQuestion = feedbackQuestion;
+        this.interviewQuestion = null;
+        if (feedbackQuestion != null && feedbackQuestion.getRecording() != this) {
+            feedbackQuestion.attachRecording(this);
         }
     }
 

--- a/src/main/java/com/dgu/review/domain/interview/repository/FeedbackQuestionRepository.java
+++ b/src/main/java/com/dgu/review/domain/interview/repository/FeedbackQuestionRepository.java
@@ -1,0 +1,8 @@
+package com.dgu.review.domain.interview.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.dgu.review.domain.interview.entity.FeedbackQuestion;
+
+public interface FeedbackQuestionRepository extends JpaRepository<FeedbackQuestion, Long> {
+
+}

--- a/src/main/java/com/dgu/review/domain/interview/service/InterviewPresignService.java
+++ b/src/main/java/com/dgu/review/domain/interview/service/InterviewPresignService.java
@@ -85,7 +85,7 @@ public class InterviewPresignService {
  public RecordingUploadUrlResponse createfeedbackQuestionRecordingPutUrl(RecordingUploadUrlRequest req, Long userId) {
      Long feedbackQuestionId=req.questionId();
      
-	 // feerbackquestion_id가 실제 db에 있는지 검증 
+	 // feedbackquestion_id가 실제 db에 있는지 검증 
 	 if(!feedbackQuestionRepository.existsById(feedbackQuestionId)) {
 		 throw new ApiException(ErrorCode.QUESTION_NOT_FOUND);
 	 };
@@ -116,7 +116,7 @@ public class InterviewPresignService {
      headers.put("Content-Type", req.contentType());
      
      //key 값 redis에 저장 
-     String redisKey="presign:recording:"+ feedbackQuestionId;
+     String redisKey="presign:recording::feedbackquestion"+ feedbackQuestionId;
      redisTemplate.opsForValue().set(redisKey, key, Duration.ofMinutes(10));
 
      return new RecordingUploadUrlResponse(

--- a/src/main/java/com/dgu/review/domain/interview/service/InterviewPresignService.java
+++ b/src/main/java/com/dgu/review/domain/interview/service/InterviewPresignService.java
@@ -215,4 +215,13 @@ private String mapResumeContentType(String ext) {
         }
         return key;
     }
+    
+    public String getFeedbackRecordingObjectKey(Long questionId) {
+        String redisKey = "presign:recording::feedbackquestion:" + questionId;
+        String key = redisTemplate.opsForValue().get(redisKey);
+        if (key == null) {
+            throw new ApiException(ErrorCode.REDIS_KEY_NOT_FOUND);
+        }
+        return key;
+    }
 }

--- a/src/main/java/com/dgu/review/domain/interview/service/InterviewPresignService.java
+++ b/src/main/java/com/dgu/review/domain/interview/service/InterviewPresignService.java
@@ -116,7 +116,7 @@ public class InterviewPresignService {
      headers.put("Content-Type", req.contentType());
      
      //key 값 redis에 저장 
-     String redisKey="presign:recording::feedbackquestion"+ feedbackQuestionId;
+     String redisKey="presign:recording::feedbackquestion::"+ feedbackQuestionId;
      redisTemplate.opsForValue().set(redisKey, key, Duration.ofMinutes(10));
 
      return new RecordingUploadUrlResponse(
@@ -217,7 +217,7 @@ private String mapResumeContentType(String ext) {
     }
     
     public String getFeedbackRecordingObjectKey(Long questionId) {
-        String redisKey = "presign:recording::feedbackquestion:" + questionId;
+        String redisKey = "presign:recording::feedbackquestion::" + questionId;
         String key = redisTemplate.opsForValue().get(redisKey);
         if (key == null) {
             throw new ApiException(ErrorCode.REDIS_KEY_NOT_FOUND);

--- a/src/main/java/com/dgu/review/domain/interview/service/InterviewPresignService.java
+++ b/src/main/java/com/dgu/review/domain/interview/service/InterviewPresignService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import com.dgu.review.domain.interview.dto.RecordingUploadUrlRequest;
 import com.dgu.review.domain.interview.dto.RecordingUploadUrlResponse;
 import com.dgu.review.domain.interview.dto.ResumeUploadUrlResponse;
+import com.dgu.review.domain.interview.repository.FeedbackQuestionRepository;
 import com.dgu.review.domain.interview.repository.InterviewQuestionRepository;
 import com.dgu.review.global.exception.ApiException;
 import com.dgu.review.global.exception.ErrorCode;
@@ -32,6 +33,7 @@ public class InterviewPresignService {
  private String bucket;
  private final InterviewQuestionRepository interviewQuestionRepository;
  private final StringRedisTemplate redisTemplate;
+ private final FeedbackQuestionRepository feedbackQuestionRepository;
 
  public RecordingUploadUrlResponse createRecordingPutUrl(RecordingUploadUrlRequest req, Long userId) {
      Long questionId=req.questionId();
@@ -80,7 +82,50 @@ public class InterviewPresignService {
              headers
      );
  }
+ public RecordingUploadUrlResponse createfeedbackQuestionRecordingPutUrl(RecordingUploadUrlRequest req, Long userId) {
+     Long feedbackQuestionId=req.questionId();
+     
+	 // feerbackquestion_id가 실제 db에 있는지 검증 
+	 if(!feedbackQuestionRepository.existsById(feedbackQuestionId)) {
+		 throw new ApiException(ErrorCode.QUESTION_NOT_FOUND);
+	 };
+	 
+	 // url 유효시간 10분 
+	 long expiryMinutes=10;
+	 
+	 // contentType을 확장자로 
+     String ext = mapExt(req.contentType());
+     String key = "recording/feedback/%d/%d.%s".formatted(userId, feedbackQuestionId, ext);
 
+     PutObjectRequest put = PutObjectRequest.builder()
+             .bucket(bucket)
+             .key(key)
+             .contentType(req.contentType())
+             .build();
+
+     PutObjectPresignRequest presign = PutObjectPresignRequest.builder()
+             .signatureDuration(Duration.ofMinutes(expiryMinutes))
+             .putObjectRequest(put)
+             .build();
+
+     PresignedPutObjectRequest signed = presigner.presignPutObject(presign);
+     URL url = signed.url();
+
+     // url로 업로드 시 반드시 동일하게 보내야 검증 통과하는 헤더 (특히 Content-Type)
+     Map<String, String> headers = new HashMap<>();
+     headers.put("Content-Type", req.contentType());
+     
+     //key 값 redis에 저장 
+     String redisKey="presign:recording:"+ feedbackQuestionId;
+     redisTemplate.opsForValue().set(redisKey, key, Duration.ofMinutes(10));
+
+     return new RecordingUploadUrlResponse(
+             url.toString(),
+             key,
+             headers
+     );
+ }
+ 
  public ResumeUploadUrlResponse createResumePutUrl(Long userId, String fileName) {
 	 // 랜덤으로 resumeId 생성 
 	 String resumeId = UUID.randomUUID().toString();  
@@ -171,4 +216,3 @@ private String mapResumeContentType(String ext) {
         return key;
     }
 }
-

--- a/src/main/java/com/dgu/review/domain/interview/service/InterviewPresignService.java
+++ b/src/main/java/com/dgu/review/domain/interview/service/InterviewPresignService.java
@@ -116,7 +116,7 @@ public class InterviewPresignService {
      headers.put("Content-Type", req.contentType());
      
      //key 값 redis에 저장 
-     String redisKey="presign:recording::feedbackquestion::"+ feedbackQuestionId;
+     String redisKey="presign:recording:feedbackquestion:"+ feedbackQuestionId;
      redisTemplate.opsForValue().set(redisKey, key, Duration.ofMinutes(10));
 
      return new RecordingUploadUrlResponse(
@@ -217,7 +217,7 @@ private String mapResumeContentType(String ext) {
     }
     
     public String getFeedbackRecordingObjectKey(Long questionId) {
-        String redisKey = "presign:recording::feedbackquestion::" + questionId;
+        String redisKey = "presign:recording:feedbackquestion:" + questionId;
         String key = redisTemplate.opsForValue().get(redisKey);
         if (key == null) {
             throw new ApiException(ErrorCode.REDIS_KEY_NOT_FOUND);

--- a/src/main/java/com/dgu/review/domain/peerfeedback/entity/PeerFeedback.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/entity/PeerFeedback.java
@@ -1,6 +1,8 @@
 package com.dgu.review.domain.peerfeedback.entity;
 
 import com.dgu.review.domain.common.entity.BaseEntity;
+import com.dgu.review.domain.interview.entity.FeedbackQuestion;
+import com.dgu.review.domain.interview.entity.InterviewQuestion;
 import com.dgu.review.domain.interview.entity.Recording;
 import com.dgu.review.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -28,7 +30,6 @@ public class PeerFeedback extends BaseEntity {
     foreignKey = @ForeignKey(name = "fk_pf_recording"))
     private Recording recording;
 
-
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false,
     foreignKey = @ForeignKey(name = "fk_pf_user"))
@@ -37,4 +38,11 @@ public class PeerFeedback extends BaseEntity {
     @Column(length = 100)
     private String followUpQuestion;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feedback_question_id", foreignKey = @ForeignKey(name="fk_pf_question"))
+    private FeedbackQuestion generatedQuestion;
+
+    public void attachGeneratedQuestion(FeedbackQuestion q) {
+        this.generatedQuestion = q;
+    }
 }


### PR DESCRIPTION
## 📝 요약
- 랜덤 질문에 대한 record url 발급 분리&키 변경

## 🔍 변경 사항
1. 랜덤 질문 엔티티 분리에 따라 s3 저장 key를 바꾸는 것이 필요해짐
- 다른 api를 사용, 같은 dto 사용, s3 key와 redis key 변경

## 📋 체크리스트
- [x] 로컬 테스트 


## ✨ 참고 사항
코드 리뷰 시 참고할 만한 사항이나 주의할 점을 작성해주세요.

## 🔗 관련 이슈
Close #49