### PR TITLE
[Fix] 시간 초과 API에서 DB에 반영하지 않던 문제 수정

### DIFF
--- a/src/main/java/com/dgu/review/domain/interview/entity/InterviewSession.java
+++ b/src/main/java/com/dgu/review/domain/interview/entity/InterviewSession.java
@@ -36,8 +36,9 @@ public class InterviewSession extends BaseEntity {
     @Column(length = 15, nullable = false)
     private String jobRole;
 
-    @Column(name = "timeout_question_numberdk")
-    private Integer timeoutQuestionNumber;
+    @Builder.Default
+    @Column(name = "timeout_question_number")
+    private Integer timeoutQuestionNumber = 0;
 
     @OneToMany(mappedBy = "interviewSession", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<InterviewQuestion> questions = new ArrayList<>();
@@ -48,5 +49,9 @@ public class InterviewSession extends BaseEntity {
     
     public void changeTitle(String newTitle) {
         this.title = newTitle;
+    }
+
+    public void addOneTimeoutQuestion() {
+        this.timeoutQuestionNumber++;
     }
 }

--- a/src/main/java/com/dgu/review/domain/interview/service/InterviewService.java
+++ b/src/main/java/com/dgu/review/domain/interview/service/InterviewService.java
@@ -60,7 +60,7 @@ public class InterviewService {
 
         InterviewSummary interviewSummary = InterviewSummary.builder()
                 .interviewTitle(session.getTitle())
-                .timeoutQuestionNumber(recordingRepository.countTimeoutsBySessionId(sessionId))
+                .timeoutQuestionNumber(session.getTimeoutQuestionNumber())
                 .questionSummaries(questionSummaries)
                 .build();
 

--- a/src/main/java/com/dgu/review/domain/interview/service/NextQuestionPlanner.java
+++ b/src/main/java/com/dgu/review/domain/interview/service/NextQuestionPlanner.java
@@ -16,6 +16,11 @@ public class NextQuestionPlanner {
         var currentRoot = getRoot(current);
         var savedFollowUp = current.getFollowUpQuestion();
 
+        if (currentRoot.getQuestionNumber() == null) {
+            log.warn("[NextQuestionPlanner] 'currentRoot' (ID: {}) has a null questionNumber. Session ID: {}",
+                    currentRoot.getId(), currentRoot.getInterviewSession().getId());
+        }
+
         // 꼬리질문 존재
         if (savedFollowUp != null) {
             return NextPayload.builder()
@@ -51,8 +56,20 @@ public class NextQuestionPlanner {
     }
 
     private InterviewQuestion findNextRoot(InterviewQuestion root) {
+        if (root.getQuestionNumber() == null) {
+            log.warn("[NextQuestionPlanner.findNextRoot] 'root' parameter (ID: {}) has a null questionNumber. Session ID: {}",
+                    root.getId(), root.getInterviewSession().getId());
+        }
         return root.getInterviewSession().getQuestions().stream()
                 .filter(q -> q.getParentQuestion() == null)
+                .peek(q -> {
+                            if (q.getQuestionNumber() == null) {
+                                log.warn("[NextQuestionPlanner.findNextRoot] Stream filter check: Found root question (ID: {}) with null questionNumber. Session ID: {}",
+                                        q.getId(), root.getInterviewSession().getId());
+                            }
+                        }
+
+                )
                 .filter(q -> q.getQuestionNumber() == root.getQuestionNumber() + 1)
                 .findFirst()
                 .orElse(null);

--- a/src/main/java/com/dgu/review/domain/interview/service/RecordingCommandService.java
+++ b/src/main/java/com/dgu/review/domain/interview/service/RecordingCommandService.java
@@ -76,6 +76,8 @@ public class RecordingCommandService {
 
         }
 
+        question.getInterviewSession().addOneTimeoutQuestion();
+
         statusService.setStatus(rec.getId(), RecordingStatus.TIMEOUT, null);
 
         NextPayload next = nextQuestionPlanner.decideNextPayload(question);


### PR DESCRIPTION
## 📝 요약
- 시간 초과 API에서 DB에 timeoutQuestionNumber를 반영하지 않던 문제를 수정하였습니다. 또한 이를 위해 timeoutQuestionNumber의 초기값을 0으로 설정하고, 테스트 과정 중 비정상적으로 저장되어있던 로컬 데이터 값을 오류를 잡기 위해 로그를 추가하였습니다.

## 🔍 변경 사항
1. timeout API에서 DB에 timeoutQuestionNumber를 +1 하는 로직 추가
2. 최종 피드백 조회 시 쿼리가 아니라 DB에 저장된 timeoutQuestionNumber를 기반으로 조회해오도록 수정

## 📋 체크리스트
- [x] timeoutQuestionNumber+1 로직 추가
- [x] 최종 피드백 조회 API 수정


## ✨ 참고 사항

## 🔗 관련 이슈
Close #52