### PR TITLE
[Fix] 프론트 로컬 개발이 가능하도록 로컬 오리진 허용

### DIFF
--- a/src/main/java/com/dgu/review/global/configuration/SecurityConfig.java
+++ b/src/main/java/com/dgu/review/global/configuration/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
 			CorsConfiguration config = new CorsConfiguration();
 			config.addAllowedOrigin("https://re-view-me.shop"); 
 			config.addAllowedOrigin("https://api.re-view-me.shop");
+			config.addAllowedOrigin("http://localhost:5173");
 			config.setAllowCredentials(true);
 			config.addAllowedHeader("*");
 			config.addAllowedMethod("*");

--- a/src/main/java/com/dgu/review/global/configuration/SecurityConfig.java
+++ b/src/main/java/com/dgu/review/global/configuration/SecurityConfig.java
@@ -107,7 +107,13 @@ public class SecurityConfig {
 
 			// 성공 후 리다이렉트 
 			log.info("로그인에 성공했습니다. kakaoId : {}", kakaoId);
-            res.sendRedirect("https://re-view-me.shop/"); 
+			// 프론트 배포 성공시 변경 
+//            res.sendRedirect("https://re-view-me.shop/"); 
+			
+			// json 반환 
+            res.setStatus(HttpServletResponse.SC_OK); // 200
+            res.setContentType("text/plain;charset=UTF-8");
+            res.getWriter().write("로그인 성공");
 		};
 	}
 

--- a/src/main/java/com/dgu/review/global/security/CookieUtils.java
+++ b/src/main/java/com/dgu/review/global/security/CookieUtils.java
@@ -36,7 +36,7 @@ public class CookieUtils {
                 .path("/")
                 .httpOnly(true)
                 .secure(true)          // HTTPS 전송만
-                .sameSite("Lax")       // same-site 명시 (서브도메인 간 OK)
+                .sameSite("None")       
                 .maxAge(Duration.ofSeconds(maxAgeSeconds))
                 .build();
         res.addHeader("Set-Cookie", cookie.toString());


### PR DESCRIPTION
## 📝 요약
- 프론트 로컬 개발이 가능하도록 로컬 오리진 허용

## 🔍 변경 사항
1. 프론트 로컬 개발이 가능하도록 로컬 오리진 허용
   - localhost 허용 
   - 배포, 로컬 환경에서 둘 다 문제 없도록 작동
2. 로그인 리다이렉트를 url이 아니라 json으로 반환하도록 수정
   - 리다이렉트가 되면 배포환경 홈으로 되어있었는데 json 반환으로 임시 수정


## 📋 체크리스트
- [x] 로컬 오리진 허용
- [x] 로컬 테스트 확인


## ✨ 참고 사항
코드 리뷰 시 참고할 만한 사항이나 주의할 점을 작성해주세요.

## 🔗 관련 이슈
Close #54 