### PR TITLE
[feat] 타인 재평가 방지 로직 추가

### DIFF
--- a/src/main/java/com/dgu/review/domain/interview/repository/RecordingRepository.java
+++ b/src/main/java/com/dgu/review/domain/interview/repository/RecordingRepository.java
@@ -50,4 +50,24 @@ public interface RecordingRepository extends JpaRepository<Recording, Long> {
         ORDER BY r.id
     """)
     List<Recording> findRootRecordingAtOffset(@Param("currentUserId") Long currentUserId, Pageable pageable);
+
+    //타인평가 시 이미 평가한 녹음 제외하고 랜덤 조회하는 쿼리
+    @Query("""
+        SELECT r
+        FROM Recording r
+        JOIN FETCH r.interviewQuestion iq
+        JOIN FETCH iq.interviewSession s
+        WHERE iq.parentQuestion IS NULL
+          AND s.user.id <> :currentUserId
+          AND r.sttText IS NOT NULL
+          AND r.sttText <> ''
+          AND r.id NOT IN (
+              SELECT pf.recording.id
+              FROM PeerFeedback pf
+              WHERE pf.user.id = :currentUserId
+          )
+        ORDER BY r.id
+    """)
+    List<Recording> findRootRecordingExcludingUserAndAlreadyEvaluated(@Param("currentUserId") Long currentUserId,
+                                                                      Pageable pageable);
 }

--- a/src/main/java/com/dgu/review/domain/peerfeedback/dto/RandomRecordingResponse.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/dto/RandomRecordingResponse.java
@@ -1,9 +1,11 @@
 package com.dgu.review.domain.peerfeedback.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Builder
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -14,4 +16,5 @@ public class RandomRecordingResponse {
     private String sttText;         // 답변 텍스트(STT)
     private String jobRole;         // 직군
     private String recordingUrl;    // S3 Presigned GET URL
+    private String message;         // 추가 메세지
 }

--- a/src/main/java/com/dgu/review/domain/peerfeedback/repository/PeerFeedbackRepository.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/repository/PeerFeedbackRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import com.dgu.review.domain.interview.entity.Recording;
 
 import java.util.List;
 
@@ -50,5 +51,5 @@ public interface PeerFeedbackRepository extends JpaRepository<PeerFeedback, Long
                 @Param("cursor") Long cursor,
                 Pageable pageable
         );
-
+    boolean existsByUserAndRecording(User user, Recording recording);
 }

--- a/src/main/java/com/dgu/review/domain/peerfeedback/service/PeerFeedbackService.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/service/PeerFeedbackService.java
@@ -44,7 +44,7 @@ public class PeerFeedbackService {
         var pageable = PageRequest.of(randomIndex, 1);
 
         Recording randomRecording = recordingRepository
-                .findRootRecordingAtOffset(currentUserId, pageable)
+                .findRootRecordingExcludingUserAndAlreadyEvaluated(currentUserId, pageable)
                 .stream()
                 .findFirst()
                 .orElseThrow(() -> new ApiException(ErrorCode.RECORDING_NOT_FOUND));
@@ -74,6 +74,10 @@ public class PeerFeedbackService {
         if (recording.getInterviewQuestion().getInterviewSession().getUser().getId()
                 .equals(evaluator.getId())) {
             throw new ApiException(ErrorCode.SELF_FEEDBACK_NOT_ALLOWED);
+        }
+        //이미 평가한 타인의 녹음 평가 방지.
+        if (peerFeedbackRepository.existsByUserAndRecording(evaluator, recording)) {
+            throw new ApiException(ErrorCode.DUPLICATE_PEER_FEEDBACK);
         }
 
         PeerFeedback feedback = PeerFeedback.builder()

--- a/src/main/java/com/dgu/review/domain/peerfeedback/service/PeerFeedbackService.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/service/PeerFeedbackService.java
@@ -37,13 +37,15 @@ public class PeerFeedbackService {
 
         long totalCount = recordingRepository.countRootRecordingsExcludingUser(currentUserId);
         if (totalCount == 0) {
-            return new RandomRecordingResponse(
-                    null,      // recordingId
-                    null,                // question
-                    null,                // sttText
-                    null,                // jobRole
-                    "현재 평가 가능한 녹음이 없습니다." // recordingUrl 대신 메시지 전달
-            );
+            return RandomRecordingResponse.builder()
+                    .recordingId(null)
+                    .question(null)
+                    .sttText(null)
+                    .jobRole(null)
+                    .recordingUrl(null)
+                    .message("현재 평가 가능한 녹음이 없습니다.")
+                    .build();
+
         }
 
         int randomIndex = new Random().nextInt((int) totalCount);
@@ -60,13 +62,14 @@ public class PeerFeedbackService {
 
         String recordingUrl = interviewObjectReadService.createRecordingGetUrl(randomRecording.getObjectKey());
 
-        return new RandomRecordingResponse(
-                randomRecording.getId(),
-                question.getQuestion(),
-                randomRecording.getSttText(),
-                session.getJobRole(),
-                recordingUrl
-        );
+        return RandomRecordingResponse.builder()
+                .recordingId(randomRecording.getId())
+                .question(question.getQuestion())
+                .sttText(randomRecording.getSttText())
+                .jobRole(session.getJobRole())
+                .recordingUrl(recordingUrl)
+                .message(null)
+                .build();
     }
 
     /**

--- a/src/main/java/com/dgu/review/domain/peerfeedback/service/PeerFeedbackService.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/service/PeerFeedbackService.java
@@ -37,7 +37,13 @@ public class PeerFeedbackService {
 
         long totalCount = recordingRepository.countRootRecordingsExcludingUser(currentUserId);
         if (totalCount == 0) {
-            throw new ApiException(ErrorCode.RECORDING_NOT_FOUND);
+            return new RandomRecordingResponse(
+                    null,      // recordingId
+                    null,                // question
+                    null,                // sttText
+                    null,                // jobRole
+                    "현재 평가 가능한 녹음이 없습니다." // recordingUrl 대신 메시지 전달
+            );
         }
 
         int randomIndex = new Random().nextInt((int) totalCount);

--- a/src/main/java/com/dgu/review/global/exception/ErrorCode.java
+++ b/src/main/java/com/dgu/review/global/exception/ErrorCode.java
@@ -114,7 +114,10 @@ public enum ErrorCode {
 	INVALID_TAG_REQUEST("InvalidTagRequest", 
 			HttpStatus.BAD_REQUEST, "선택된 태그가 없습니다. "),
 	TAG_LIMIT_EXCEEDED("TagLimitExceeded", 
-			HttpStatus.BAD_REQUEST, "태그는 최대 3개까지 선택할 수 있습니다.")
+			HttpStatus.BAD_REQUEST, "태그는 최대 3개까지 선택할 수 있습니다."),
+
+    DUPLICATE_PEER_FEEDBACK("DUPLICATE_PEER_FEEDBACK",
+            HttpStatus.BAD_REQUEST, "이미 해당 녹음에 대한 피드백이 존재합니다."),
 	;
 
 	private final String code;


### PR DESCRIPTION
## 📝 요약
- 타인평가(PeerFeedback) 기능에서 사용자가 이미 평가한 녹음을 다시 평가할 수 있는 문제를 수정했습니다.
- 기존에는 getRandomRecording()에서 “본인 녹음 제외”만 적용되어, 동일한 타인 녹음이 반복 노출될 수 있었습니다.
- createFeedback()에서 동일 녹음에 대해 중복 피드백을 남기는 것도 가능했습니다.

랜덤 조회 시 중복 평가 제외, 저장 시 중복 예외 처리를 추가

## 🔍 변경 사항
1. RecordingRepository 
   - findRootRecordingExcludingUserAndAlreadyEvaluated() 쿼리 추가하여 현재 사용자(userId)의 녹음과 이미 평가한 녹음을 모두 제외한 랜덤 조회 구현
2. PeerFeedbackRepository 
    - existsByUserAndRecording() 메서드 추가하여 동일 사용자가 동일 녹음을 이미 평가했는지 여부 확
3. PeerFeedbackService
    - createFeedback() 내부에 중복 평가 방지 로직 추가
4. ErrorCode - DUPLICATE_PEER_FEEDBACK 항목 추가


## 📋 체크리스트
- [] 동일 녹음에 중복 피드백 시 DUPLICATE_PEER_FEEDBACK 예외 발생 확인
- 로컬 Swagger 테스트 완료


## ✨ 참고 사항


## 🔗 관련 이슈
Close #58 