### PR TITLE
[Fix] 꼬리질문이 있는 질문에 대해 레디스 키를 업데이트하지 않는 문제 해결

### DIFF
--- a/src/main/java/com/dgu/review/domain/interview/service/RecordingTranscriber.java
+++ b/src/main/java/com/dgu/review/domain/interview/service/RecordingTranscriber.java
@@ -112,9 +112,10 @@ public class RecordingTranscriber {
                     log.error("[feedback] async job failed, rootId={}", rootQ.getId(), e);
                 }
 
-                statusService.setStatus(recordingId, RecordingStatus.FOLLOWUP_GENERATED, Duration.ofDays(1));
-
             }
+
+            statusService.setStatus(recordingId, RecordingStatus.FOLLOWUP_GENERATED, Duration.ofDays(1));
+
         } catch (Exception e) {
             statusService.setStatus(recordingId, RecordingStatus.FAILED, null);
             recording.updateFailedAt(LocalDateTime.now());


### PR DESCRIPTION
## 📝 요약
- 기존 코드에서 정상적으로 꼬리질문이 생성된 recording에 대해서 polling 조회 시 계속 working으로 표시되는 문제가 있었습니다. 이에 꼬리질문이 없는 질문에 대해서만 레디스 키를 업데이트하고 꼬리질문이 있는 질문에 대해서는 레디스 키를 `followup_generated`로 업데이트하지 않던 문제를 해결했습니다. 

## 🔍 변경 사항
1. 버그 수정
- redis 키 변경 코드를 if(createdFollowUp) if문 바깥으로 빼서, 꼬리질문 생성 여부에 관계 없이 키를 변경하도록 수정


## 📋 체크리스트
- [x] 버그 수정


## ✨ 참고 사항

## 🔗 관련 이슈
Close #63 