### PR TITLE
[Refactor] 로그인 배포환경에 맞게 수정

### DIFF
--- a/src/main/java/com/dgu/review/domain/peerfeedback/service/PeerFeedbackService.java
+++ b/src/main/java/com/dgu/review/domain/peerfeedback/service/PeerFeedbackService.java
@@ -14,13 +14,15 @@ import com.dgu.review.global.exception.ApiException;
 import com.dgu.review.global.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import com.dgu.review.domain.interview.service.InterviewObjectReadService;
 
 import java.util.Random;
 
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -36,6 +38,8 @@ public class PeerFeedbackService {
     public RandomRecordingResponse getRandomRecording(Long currentUserId) {
 
         long totalCount = recordingRepository.countRootRecordingsExcludingUser(currentUserId);
+        log.info("내 이름 : " + currentUserId);
+        log.info("갯수 : " + totalCount);
         if (totalCount == 0) {
             return RandomRecordingResponse.builder()
                     .recordingId(null)

--- a/src/main/java/com/dgu/review/global/configuration/SecurityConfig.java
+++ b/src/main/java/com/dgu/review/global/configuration/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.dgu.review.global.configuration;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
@@ -62,7 +61,7 @@ public class SecurityConfig {
 			return config;
 		})).authorizeHttpRequests(auth -> auth
 				.requestMatchers("/", "/health", "/favicon.ico", "/error", "/oauth2/authorization/kakao", "/actuator/health",
-						"/login/oauth2/code/kakao", "/swagger-ui/**", "/v3/api-docs/**")
+						"/login/oauth2/code/kakao", "/swagger-ui/**", "/v3/api-docs/**", "/api/community/pages/**")
 				.permitAll().anyRequest().authenticated())
 				.exceptionHandling(e -> e
 						.authenticationEntryPoint(restAuthEntryPoint) 
@@ -107,12 +106,8 @@ public class SecurityConfig {
 
 			// 성공 후 리다이렉트 
 			log.info("로그인에 성공했습니다. kakaoId : {}", kakaoId);
-			// 프론트 배포 성공시 변경 
-            res.sendRedirect("http://localhost:5173/"); 
-			// json 반환 
-//            res.setStatus(HttpServletResponse.SC_OK); // 200
-//            res.setContentType("text/plain;charset=UTF-8");
-//            res.getWriter().write("로그인 성공");
+			// 프론트 홈으로 반환 
+            res.sendRedirect("https://re-view-me.shop/"); 
 		};
 	}
 
@@ -121,7 +116,7 @@ public class SecurityConfig {
 		return (HttpServletRequest req, HttpServletResponse res, AuthenticationException ex) -> {
 			// 실패 로그
 			log.error("🚨OAuth2 login failed", ex);
-			// 프론트 연동 시 사용할 리다이렉트 
+			// 프론트로 메세지와 함께 반환 
 			 res.sendRedirect("/login?error=" + (ex.getMessage() == null ? "oauth2_failed" : ex.getMessage()));
 		};
 	}


### PR DESCRIPTION
## 📝 요약
- 로그인 배포환경에 맞게 수정

## 🔍 변경 사항
1. 로그인 성공시 리다이렉트를 로컬에서 배포 홈 화면으로 변경
2. 로그인 필요없는 api 추가
  - 기존에는 모든 api가 로그인이 필요하게끔 설정해둠
3. 타인평가에서 로그 추가
  - 랜덤 질문 후보군 갯수를 로그 출력으로 추가 


## 📋 체크리스트
- [x] 로컬 테스트 


## ✨ 참고 사항
코드 리뷰 시 참고할 만한 사항이나 주의할 점을 작성해주세요.

## 🔗 관련 이슈
Close #65 